### PR TITLE
Remove const from DiffOp enum

### DIFF
--- a/src/diff-op.enum.ts
+++ b/src/diff-op.enum.ts
@@ -1,4 +1,4 @@
-export const enum DiffOp {
+export enum DiffOp {
   Delete = -1,
   Equal = 0,
   Insert = 1


### PR DESCRIPTION
Removed const from DiffOp enum because I was unable to use the enum for constructing HTML from a diff with typescripts `"isolatedModules": true`

Explanation: https://ncjamieson.com/dont-export-const-enums/
Typescript docs: https://www.typescriptlang.org/tsconfig#references-to-const-enum-members