### PR TITLE
Add undefined type to opt_b and opt_c in patch_make()

### DIFF
--- a/src/diff-match-patch.class.ts
+++ b/src/diff-match-patch.class.ts
@@ -457,8 +457,8 @@ export class DiffMatchPatch {
    */
   public patch_make(
     a: string | Diff[],
-    opt_b: string | Diff[] | undefined,
-    opt_c: string | Diff[] | undefined,
+    opt_b?: string | Diff[],
+    opt_c?: string | Diff[],
   ): PatchOperation[] {
     let text1;
     let diffs;

--- a/src/diff-match-patch.class.ts
+++ b/src/diff-match-patch.class.ts
@@ -457,8 +457,8 @@ export class DiffMatchPatch {
    */
   public patch_make(
     a: string | Diff[],
-    opt_b: string | Diff[],
-    opt_c: string | Diff[],
+    opt_b: string | Diff[] | undefined,
+    opt_c: string | Diff[] | undefined,
   ): PatchOperation[] {
     let text1;
     let diffs;


### PR DESCRIPTION
Hey, first off thank you so much for this library

I'm trying to use patch_make() and running into an issue when compiling my typescript where to use method 2 of patch_make you need to pass 'undefined'. I'm able to get around this by either not passing the opt_c argument or ignoring the error and setting it to 'undefined,' but it fails when building in github workflow

I think just adding 'undefined' to the allowed types would do it